### PR TITLE
Migrate from Deno to Gleam with hinoto

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,19 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Setup Gleam
+        uses: erlef/setup-beam@v1
         with:
-          cache: true
+          otp-version: "28"
+          gleam-version: "1.14.0"
+          rebar3-version: "3"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Download Gleam dependencies
+        run: gleam deps download
 
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v4

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-![Last commit](https://img.shields.io/github/last-commit/Comamoca/baserepo?style=flat-square)
-![Repository Stars](https://img.shields.io/github/stars/Comamoca/baserepo?style=flat-square)
-![Issues](https://img.shields.io/github/issues/Comamoca/baserepo?style=flat-square)
-![Open Issues](https://img.shields.io/github/issues-raw/Comamoca/baserepo?style=flat-square)
-![Bug Issues](https://img.shields.io/github/issues/Comamoca/baserepo/bug?style=flat-square)
+![Last commit](https://img.shields.io/github/last-commit/Comamoca/emoji2svg?style=flat-square)
+![Repository Stars](https://img.shields.io/github/stars/Comamoca/emoji2svg?style=flat-square)
+![Issues](https://img.shields.io/github/issues/Comamoca/emoji2svg?style=flat-square)
+![Open Issues](https://img.shields.io/github/issues-raw/Comamoca/emoji2svg?style=flat-square)
+![Bug Issues](https://img.shields.io/github/issues/Comamoca/emoji2svg/bug?style=flat-square)
 ![Uptime Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Comamoca/status/master/api/emoji2svg/uptime-day.json&style=flat-square)
 
 <img src="https://emoji2svg.comamoca.dev/api/🍣" alt="eyecatch" height="100">


### PR DESCRIPTION
## Summary

Migrate the emoji2svg Worker from Deno to **Gleam with [hinoto](https://github.com/lpil/hinoto)**.

## Changes

- :sparkles: Rewrite the Worker in Gleam (`src/emoji2svg.gleam`) with hinoto
- :white_check_mark: Add vitest-pool-workers integration tests
- :wrench: Add Renovate dependency update config
- :wrench: Add Nix flake for reproducible dev environment
- :books: Update README badges to correct URLs

## Notes

- Deno files (`deno.jsonc`, `deno.lock`, `main.ts`) removed
- Deploy workflow updated to install Gleam