### PR TITLE
:bug: Log percent-decoded emoji

### DIFF
--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -104,9 +104,14 @@ pub fn main() {
       |> hinoto.handle(fn(req) {
         case request.path_segments(req) {
           ["api", str] -> {
+            let emoji = case uri.percent_decode(str) {
+              Ok(decoded) -> decoded
+              Error(_) -> str
+            }
+
             log
             |> logger.info("emoji request", [
-              logger.string("emoji", str),
+              logger.string("emoji", emoji),
             ])
 
             emoji_api(str)


### PR DESCRIPTION
## What

`request.path_segments` does not URL-decode segments, so the `emoji` field in the structured logs was percent-encoded (e.g. `%F0%9F%A6%8A`).

This PR decodes the emoji with `uri.percent_decode` before logging it, falling back to the raw string on decode failure.

## Changes

| File | Change |
|---|---|
| `src/emoji2svg.gleam` | Decode emoji before logging |

## Verification

- `gleam build --target javascript` passes
- `gleam test --target javascript` passes (9 tests)
