### PR TITLE
:sparkles: Configure log level to Info and include emoji in message

### DIFF
--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -7,6 +7,8 @@ import gleam/list
 import gleam/result
 import gleam/string
 import gleam/uri
+import glogg/handler
+import glogg/level
 import glogg/logger
 import hinoto
 import hinoto/body.{type Body}
@@ -96,6 +98,8 @@ pub fn emoji_api(str: String) -> Promise(response.Response(Body)) {
 ///
 /// Routes `/api/<emoji>` to the SVG converter, everything else to 404.
 pub fn main() {
+  handler.set_default_handler_minimum_level(level.Info)
+
   let log = logger.new("emoji2svg")
 
   workers.serve(fn(hinoto) {
@@ -110,7 +114,7 @@ pub fn main() {
             }
 
             log
-            |> logger.info("emoji request", [
+            |> logger.info("emoji request: " <> emoji, [
               logger.string("emoji", emoji),
             ])
 


### PR DESCRIPTION
## What

The JS default handler's minimum log level is `notice`, so `logger.info(...)` calls were silently dropped. This PR:

- Sets the default handler minimum level to `Info` via `handler.set_default_handler_minimum_level(level.Info)`
- Includes the requested emoji in the log message (`"emoji request: 🦊"`), while keeping the `emoji` field for filtering

## Changes

| File | Change |
|---|---|
| `src/emoji2svg.gleam` | Set handler level to Info, add emoji to message |

## Verification

- `gleam build --target javascript` passes
- `gleam test --target javascript` passes (9 tests)
- Confirmed log output shape: `{"level":"info","msg":"emoji request: 🦊","emoji":"🦊","logger":"emoji2svg"}`
