### PR TITLE
:zap: Cache SVG responses with Workers Cache

### DIFF
--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -62,8 +62,15 @@ fn text_response(
 }
 
 /// Returns the given SVG string as a 200 OK response.
+///
+/// Sets a long `Cache-Control` so the Worker response can be cached by
+/// Workers Cache at the edge.
 pub fn return_svg(svg: String) -> response.Response(Body) {
   text_response(200, svg, "image/svg+xml")
+  |> response.set_header(
+    "cache-control",
+    "public, max-age=604800, s-maxage=604800",
+  )
 }
 
 /// Returns a 500 Internal Server Error response.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,9 @@ compatibility_date = "2023-09-22"
 [observability]
 enabled = true
 
+[cache]
+enabled = true
+
 [build]
 command = "gleam build --target javascript"
 


### PR DESCRIPTION
## What

Cache SVG responses at the edge with [Workers Cache](https://blog.cloudflare.com/workers-cache/) so repeat requests for the same emoji skip the Worker entirely.

- Enable Workers Cache in `wrangler.toml` (`[cache] enabled = true`)
- Set `Cache-Control: public, max-age=604800, s-maxage=604800` on SVG responses in `return_svg`

## Why

Every request was hitting jsDelivr for the twemoji SVG, even though the asset is immutable. With Workers Cache:

1. First request for an emoji runs the Worker and fetches from jsDelivr
2. The response is cached at the edge for 7 days
3. Repeat requests are served from cache — the Worker (and the subrequest) never runs

This is a config + header change only; no FFI or JS code needed.

## Changes

| File | Change |
|---|---|
| `wrangler.toml` | Enable `[cache]` |
| `src/emoji2svg.gleam` | Add `Cache-Control` header to `return_svg` |

## Verification

- `gleam build --target javascript` passes
- `gleam test --target javascript` passes (9 tests)
- `gleam format --check` passes
- `wrangler deploy --dry-run` passes (validates the `[cache]` config)
