### PR TITLE
:wrench: Enable observability logs in wrangler.toml

### DIFF
--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -7,6 +7,8 @@ import gleam/list
 import gleam/result
 import gleam/string
 import gleam/uri
+import glogg/handler
+import glogg/level
 import glogg/logger
 import hinoto
 import hinoto/body.{type Body}
@@ -96,6 +98,8 @@ pub fn emoji_api(str: String) -> Promise(response.Response(Body)) {
 ///
 /// Routes `/api/<emoji>` to the SVG converter, everything else to 404.
 pub fn main() {
+  handler.set_default_handler_minimum_level(level.Info)
+
   let log = logger.new("emoji2svg")
 
   workers.serve(fn(hinoto) {
@@ -110,7 +114,7 @@ pub fn main() {
             }
 
             log
-            |> logger.info("emoji request", [
+            |> logger.info("emoji request: " <> emoji, [
               logger.string("emoji", emoji),
             ])
 

--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -104,9 +104,14 @@ pub fn main() {
       |> hinoto.handle(fn(req) {
         case request.path_segments(req) {
           ["api", str] -> {
+            let emoji = case uri.percent_decode(str) {
+              Ok(decoded) -> decoded
+              Error(_) -> str
+            }
+
             log
             |> logger.info("emoji request", [
-              logger.string("emoji", str),
+              logger.string("emoji", emoji),
             ])
 
             emoji_api(str)

--- a/src/emoji2svg.gleam
+++ b/src/emoji2svg.gleam
@@ -62,8 +62,15 @@ fn text_response(
 }
 
 /// Returns the given SVG string as a 200 OK response.
+///
+/// Sets a long `Cache-Control` so the Worker response can be cached by
+/// Workers Cache at the edge.
 pub fn return_svg(svg: String) -> response.Response(Body) {
   text_response(200, svg, "image/svg+xml")
+  |> response.set_header(
+    "cache-control",
+    "public, max-age=604800, s-maxage=604800",
+  )
 }
 
 /// Returns a 500 Internal Server Error response.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,9 @@ compatibility_date = "2023-09-22"
 [observability]
 enabled = true
 
+[cache]
+enabled = true
+
 [build]
 command = "gleam build --target javascript"
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,3 +13,10 @@ command = "gleam build --target javascript"
 
 [assets]
 directory = "./public"
+
+[observability.logs]
+enabled = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false


### PR DESCRIPTION
Enable Workers observability logs (invocation logs on, traces off).